### PR TITLE
Change host parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,26 +21,26 @@ export class CaGovBenefitsRecs extends window.HTMLElement {
 
     this.html = html;
     this.css = css;
-    this.benefitsAPI =
-      "https://k61aw4mwkc.execute-api.us-west-1.amazonaws.com/";
   }
 
   connectedCallback() {
-    this.language = document.querySelector("html").getAttribute("lang");
-    this.income = "";
+    this.benefitsAPI = this.hasAttribute("endpoint")
+      ? this.getAttribute("endpoint")
+      : "https://k61aw4mwkc.execute-api.us-west-1.amazonaws.com/";
 
-    if (this.hasAttribute("language")) {
-      this.language = this.getAttribute("language");
-    }
-    if (this.hasAttribute("endpoint")) {
-      this.benefitsAPI = this.getAttribute("endpoint");
-    }
-    if (this.hasAttribute("income")) {
-      this.income = this.getAttribute("income");
-    }
-    if (this.hasAttribute("host")) {
-      this.host = this.getAttribute("host");
-    }
+    const lang = document.querySelector("html").getAttribute("lang");
+
+    this.language = this.hasAttribute("language")
+      ? this.getAttribute("language")
+      : lang;
+
+    this.income = this.hasAttribute("income")
+      ? this.getAttribute("income")
+      : "";
+
+    this.host = this.hasAttribute("host")
+      ? this.getAttribute("host")
+      : window.location.href;
 
     // create widget environment data object to pass to API
     this.widgetEnvData = {};
@@ -55,13 +55,15 @@ export class CaGovBenefitsRecs extends window.HTMLElement {
     const queryKeys = ["host", "language"];
     const queryString = queryKeys
       .reduce((bucket, key) => {
-        if (this[key]) bucket.push(`${key}=${this[key]}`);
+        if (this[key]) bucket.push(`${key}=${encodeURIComponent(this[key])}`);
         return bucket;
       }, [])
       .join("&");
 
+    const benefitsURL = `${this.benefitsAPI}benefits?${queryString}`;
+
     // retrieve set of benefits links from API
-    fetch(`${this.benefitsAPI}benefits?${queryString}`, {
+    fetch(benefitsURL, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/test/index.html
+++ b/test/index.html
@@ -5,14 +5,20 @@
   </head>
   <body>
     <main>
-    <h1>Benefits recommendation test page</h1>
-    <ul>
-      <li>this list is outside the web component so unaffected by styles inside the shadow root</li>
-    </ul>
-    <cagov-benefits-recs host="test" endpoint="http://localhost:3333/"></cagov-benefits-recs>
-    <script type="module" src="../src/index.js"></script>
+      <h1>Benefits recommendation test page</h1>
+      <ul>
+        <li>
+          this list is outside the web component so unaffected by styles inside
+          the shadow root
+        </li>
+      </ul>
+      <cagov-benefits-recs
+        host="https://sdio.edd.ca.gov/DIAE/Pages/ExternalUser/InitialClaim/Confirmation.aspx"
+        endpoint="http://localhost:3333/"
+      ></cagov-benefits-recs>
+      <script type="module" src="../src/index.js"></script>
 
-<!--
+      <!--
   Add an endpoint attribute to the custom element to test different API environments
 
   dev:
@@ -24,7 +30,7 @@
   production:
   endpoint="https://k61aw4mwkc.execute-api.us-west-1.amazonaws.com/"
 -->
-    <p>paragraph underneath the widget</p>
+      <p>paragraph underneath the widget</p>
     </main>
   </body>
 </html>


### PR DESCRIPTION
This PR changes the `host` attribute of the benefits recommender widget.

Before, the widget expected a "host code" associated with the placement partner. (`CALFRESH` was an example of a host code.)

Before: 

```html
<!-- In all scenarios, dev and prod -->
<cagov-benefits-recs host="CALFRESH"></cagov-benefits-recs>
```

Here, instead the widget expects the `host` attribute to supply a full URL. 

This PR:

```html
<!-- In dev -->
<cagov-benefits-recs host="https://myfamily.wic.ca.gov/Home/AmIEligible"></cagov-benefits-recs>

<!-- In prod -->
<cagov-benefits-recs></cagov-benefits-recs>
```

This revised `host` attribute is optional. The widget will automatically determine the `host` value if it's not defined. The main use here is to spoof placement locations in development, so we (and end-devs) can test how the widget will render on different domains and pages. It's not recommended in any production context. 

There are a few drivers for this change. We determined we need to sniff out the host page URL within the widget, after all, to affect how target links are chosen and then formatted for analytics ("utm_source" URL query parameters, etc.). Driving everything through URL feels more straightforward than mixing URLs and special host codes.

This corresponds to another PR on the back-end too, cagov/benefits-recommendation-widget-back#15.